### PR TITLE
Run checks and tests in Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,14 @@ WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-# Copy the source code into the container 
-COPY src/ .
+# Copy source code, tests, and scripts
+COPY src/ /app/src/
+COPY tests/ /app/tests/
+COPY scripts/ /app/scripts/
+
+# Make scripts executable
+RUN chmod +x /app/scripts/*.sh
 
 # Define the entrypoint to execute the script 
 # The script will analyze the repository mounted at /app/repo
-ENTRYPOINT ["python", "generate_readme_llm.py", "/app/repo"]
+# ENTRYPOINT ["python", "/app/src/generate_readme_llm.py", "/app/repo"]

--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,13 @@ IMAGE_NAME := readme-llm-generator
 # This allows it to be passed from the command line.
 REPO_PATH ?=
 
+# Export IMAGE_NAME for scripts to use
+export IMAGE_NAME
+
 # --- Shell Scripts ---
 # Define paths to the scripts for easier maintenance
 BUILD_SCRIPT := ./scripts/create-image.sh
-RUN_SCRIPT   := ./scripts/generate-readme-llm.sh
+# RUN_SCRIPT is no longer needed as generate-readme-llm.sh is called directly.
 
 # --- Commands ---
 # .PHONY declares targets that are not actual files.
@@ -25,10 +28,10 @@ help:
 	@echo ""
 	@echo "Usage:"
 	@echo "  make setup    - 🚀 Create the .env file from the example to get started."
-	@echo "  make build    - 🛠️  Build the Docker image by calling the build script."
+	@echo "  make build    - 🛠️  Build the Docker image. Uses scripts/create-image.sh if defined, or direct docker build."
 	@echo "  make run      - ✨ Run the generator. Requires a path. Usage: make run REPO_PATH=/path/to/your/repo"
-	@echo "  make test     - 🧪 Run the test suite using pytest."
-	@echo "  make check    - ✅ Run checks (e.g., type checking, linting)."
+	@echo "  make test     - 🧪 Run the test suite using pytest (now runs in Docker via script)."
+	@echo "  make check    - ✅ Run checks (e.g., type checking, linting) (now runs in Docker via script)."
 	@echo "  make clean    - 🧹 Remove dangling Docker images to save space."
 	@echo "  make help     - ℹ️  Display this help message."
 	@echo ""
@@ -46,22 +49,17 @@ build:
 	@echo "--- Calling build script ---"
 	@$(BUILD_SCRIPT)
 
-run:
-	@if [ -z "$(REPO_PATH)" ]; then \
-		echo "❌ Error: REPO_PATH is not set."; \
-		echo "Usage: make run REPO_PATH=/path/to/your/repo"; \
-		exit 1; \
-	fi
-	@echo "--- Calling run script for repository: $(REPO_PATH) ---"
-	@$(RUN_SCRIPT) "$(REPO_PATH)"
+run: build
+	@echo "--- Calling script to run README generator for REPO_PATH: $(REPO_PATH) ---"
+	@./scripts/generate-readme-llm.sh "$(REPO_PATH)"
 
-test:
-	@echo "--- Running test suite ---"
+test: build
+	@echo "--- Calling script to run test suite ---"
 	@./scripts/run-tests.sh
 
-check:
-	@echo "Running checks..."
-	@scripts/check.sh
+check: build
+	@echo "--- Calling script to run checks ---"
+	@./scripts/check.sh
 
 clean:
 	@echo "--- Removing dangling Docker images ---"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 google-generativeai
 python-dotenv
 pytest
+mypy

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -1,17 +1,31 @@
 #!/bin/bash
+# Script to run checks, potentially inside a Docker container
 
 # Exit immediately if a command exits with a non-zero status.
 set -e
 
-# Install mypy if not already installed
-if ! python -m mypy --version > /dev/null 2>&1; then
-  echo "mypy not found. Please install it as part of your project's development dependencies."
-  echo "For example: python -m pip install mypy"
-  exit 1
+# Use IMAGE_NAME from environment variable, default if not set
+EFFECTIVE_IMAGE_NAME="${IMAGE_NAME:-readme-llm-generator}"
+
+if [ "$IS_IN_DOCKER" == "true" ]; then
+    # --- Running inside Docker ---
+    echo "--- Already inside Docker, running checks ---"
+    echo "Changing to /app/repo directory..."
+    cd /app/repo
+
+    echo "Running mypy type checking..."
+    python -m mypy src/ tests/
+    echo "Type checking completed successfully."
+else
+    # --- Not running inside Docker, re-execute in Docker ---
+    echo "--- Not inside Docker, re-launching in Docker image: ${EFFECTIVE_IMAGE_NAME} ---"
+    docker run \
+        --rm \
+        -v "$(pwd):/app/repo" \
+        -e IS_IN_DOCKER=true \
+        -e IMAGE_NAME="${EFFECTIVE_IMAGE_NAME}" \
+        "${EFFECTIVE_IMAGE_NAME}" \
+        /app/scripts/check.sh # Path to this script *inside the container*
 fi
 
-# Run mypy on the src and tests directories
-echo "Running mypy type checking..."
-python -m mypy src/ tests/
-
-echo "Type checking completed successfully."
+echo "--- Check script finished ---"

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -1,14 +1,30 @@
 #!/bin/bash
+# Script to run tests, potentially inside a Docker container
 
-# Check if pytest is installed
-if ! command -v pytest &> /dev/null
-then
-    echo "pytest could not be found, installing..."
-    pip install pytest
+# Exit immediately if a command exits with a non-zero status.
+set -e
+
+# Use IMAGE_NAME from environment variable, default if not set
+EFFECTIVE_IMAGE_NAME="${IMAGE_NAME:-readme-llm-generator}"
+
+if [ "$IS_IN_DOCKER" == "true" ]; then
+    # --- Running inside Docker ---
+    echo "--- Already inside Docker, running tests ---"
+    echo "Changing to /app/repo directory..."
+    cd /app/repo
+
+    echo "Running pytest..."
+    pytest
 else
-    echo "pytest is already installed."
+    # --- Not running inside Docker, re-execute in Docker ---
+    echo "--- Not inside Docker, re-launching in Docker image: ${EFFECTIVE_IMAGE_NAME} ---"
+    docker run \
+        --rm \
+        -v "$(pwd):/app/repo" \
+        -e IS_IN_DOCKER=true \
+        -e IMAGE_NAME="${EFFECTIVE_IMAGE_NAME}" \
+        "${EFFECTIVE_IMAGE_NAME}" \
+        /app/scripts/run-tests.sh # Path to this script *inside the container*
 fi
 
-# Run pytest from the root of the repository
-echo "Running pytest..."
-pytest
+echo "--- Test script finished ---"


### PR DESCRIPTION
The `run-tests.sh` and `check.sh` scripts have been updated to remove the conditional `pip install` commands for `pytest` and `mypy` respectively.

These tools are included in `requirements.txt` and are expected to be present in the Docker image. The scripts now rely solely on the Docker image's pre-installed dependencies, simplifying the scripts and making the execution cleaner.

This change assumes the Docker image is built with all necessary dependencies before these scripts are run.