### PR TITLE
Fix: Prevent shell expansion of include/exclude patterns in generate-…

### DIFF
--- a/scripts/generate-readme-llm.sh
+++ b/scripts/generate-readme-llm.sh
@@ -16,7 +16,7 @@ if [ -n "$1" ]; then
     REPO_PATH_ARG="$1"
     echo "Debug (wrapper): REPO_PATH_ARG set to $REPO_PATH_ARG from \$1"
     shift # Remove repo path, remaining $@ are include/exclude options
-    PASSTHROUGH_ARGS="$@" # Store the remaining arguments
+    PASSTHROUGH_ARGS=("$@") # Store the remaining arguments
 else
     echo "❌ Error (wrapper): REPO_PATH argument is not set."
     echo "Usage: ./scripts/generate-readme-llm.sh /absolute/path/to/your/repo [--include PATTERN] [--exclude PATTERN]"
@@ -53,6 +53,6 @@ docker run \
     -e IMAGE_NAME="${EFFECTIVE_IMAGE_NAME}" \
     -e PYTHONUNBUFFERED=1 \
     "${EFFECTIVE_IMAGE_NAME}" \
-    python /app/src/generate_readme_llm.py /app/repo ${PASSTHROUGH_ARGS}
+    python /app/src/generate_readme_llm.py /app/repo "${PASSTHROUGH_ARGS[@]}"
 
 echo "--- Wrapper script: README generator process finished ---"


### PR DESCRIPTION
…readme-llm.sh

The include/exclude patterns provided to the \`generate-readme-llm.sh\` script were subject to shell glob expansion before being passed to the underlying Python script. This meant that patterns like '*.py' would be expanded to a list of matching files in the current directory of the shell, rather than being passed as a literal pattern to the Python script for processing within the target repository.

This commit fixes the issue by:
1. Storing passthrough arguments in a Bash array (\`PASSTHROUGH_ARGS=("$@")\`) to preserve the literal value of each argument, including spaces and special characters.
2. Correctly passing the array of arguments to the \`docker run\` command (\`"${PASSTHROUGH_ARGS[@]}"\`) so that each argument is treated as a distinct string by the Python script.

This ensures that the Python script receives the include/exclude patterns exactly as specified by you, allowing it to perform the pattern matching correctly within the context of the target repository.